### PR TITLE
Refactor commands and implement caching for warps and homes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -96,10 +96,12 @@ tasks {
             include(".dependencies")
         }
 
-        expand(
-            "version" to project.version,
-            "name" to project.name,
-        )
+        filesMatching("paper-plugin.yml") {
+            expand(
+                "version" to project.version,
+                "name" to project.name,
+            )
+        }
     }
 
     register<JavaCompile>("compileMain") {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 kotlin.code.style=official
 
 minecraftVersion=1.21.1
-pluginVersion=b1
+pluginVersion=b2
 
 exposedVersion=0.51.1
 hikariCPVersion=5.1.0

--- a/src/main/kotlin/cc/modlabs/basicx/BasicX.kt
+++ b/src/main/kotlin/cc/modlabs/basicx/BasicX.kt
@@ -1,6 +1,8 @@
 package cc.modlabs.basicx
 
 import cc.modlabs.basicx.cache.MessageCache
+import cc.modlabs.basicx.cache.WarpCache
+import cc.modlabs.basicx.cache.HomeCache
 import cc.modlabs.basicx.managers.RegisterManager
 import org.bukkit.plugin.java.JavaPlugin
 import kotlin.system.measureTimeMillis
@@ -21,10 +23,14 @@ class BasicX : JavaPlugin() {
 
         // Copy the messages file to the plugins folder
         saveResource("messages.yml", false)
+        saveResource("warps.yml", false)
+        saveResource("homes.yml", false)
 
         // Plugin startup logic
         val time = measureTimeMillis {
             MessageCache.loadCache()
+            WarpCache.loadCache()
+            HomeCache.loadCache()
         }
 
         RegisterManager.registerListeners(this)

--- a/src/main/kotlin/cc/modlabs/basicx/BasicX.kt
+++ b/src/main/kotlin/cc/modlabs/basicx/BasicX.kt
@@ -23,8 +23,6 @@ class BasicX : JavaPlugin() {
 
         // Copy the messages file to the plugins folder
         saveResource("messages.yml", false)
-        saveResource("warps.yml", false)
-        saveResource("homes.yml", false)
 
         // Plugin startup logic
         val time = measureTimeMillis {

--- a/src/main/kotlin/cc/modlabs/basicx/CommandBootstrapper.kt
+++ b/src/main/kotlin/cc/modlabs/basicx/CommandBootstrapper.kt
@@ -13,105 +13,139 @@ class CommandBootstrapper : PluginBootstrap {
         manager.registerEventHandler(LifecycleEvents.COMMANDS) { event ->
             val commands = event.registrar()
 
-            commands.register(
-                createBasicXCommand(),
-                "Plugin management"
-            )
-
-            commands.register(
-                createTPCommand(),
-                "Teleport to a player or coordinates"
-            )
-
-            commands.register(
-                createTPACommand(),
-                "Request to teleport to a player"
-            )
-
-            commands.register(
-                registerInvSeeCommand(),
-                "View another player's inventory"
-            )
-
-            commands.register(
-                VanishCommand().createVanishCommand(),
-                "Toggle vanish mode"
-            )
-
-            commands.register(
-                createGMCommand(),
-                "Change game mode"
-            )
-
-            commands.register(
-                ItemEditCommand().register().build(),
-                "Edit items (sign, enchant, rename)"
-            )
-
-            commands.register(
-                createTrashCommand(),
-                "Open trash GUI"
-            )
-
-            commands.register(
-                FeedCommand.createFeedCommand(),
-                "Feed a player"
-            )
-
-            commands.register(
-                HealCommand.createHealCommand(),
-                "Heal a player"
-            )
-
-            commands.register(
-                FlyCommand.createFlyCommand(),
-                "Toggle fly mode"
-            )
-
-            commands.register(
-                AnvilCommand.register(),
-                "Open anvil GUI"
-            )
-
-            commands.register(
-                WarpCommand.createWarpCommand(),
-                "Warp to a location"
-            )
-
-            commands.register(
-                CreateWarpCommand.createWarpCommand(),
-                "Create a warp"
-            )
-
-            commands.register(
-                DeleteWarpCommand.createDeleteWarpCommand(),
-                "Delete a warp"
-            )
-
-            commands.register(
-                HomesCommand.createHomesCommand(),
-                "Manage homes"
-            )
-
-            commands.register(
-                createEconomyCommand(),
-                "Economy commands"
-            )
-
-            commands.register(
-                KitCommand.createKitCommand(),
-                "Receive a kit"
-            )
-
-            commands.register(
-                createTimeCommand(),
-                "Set or add time"
-            )
-
-            commands.register(
-                WeatherCommand().createWeatherCommand(),
-                "Set weather"
-            )
+            registerPluginManagementCommands(commands)
+            registerTeleportationCommands(commands)
+            registerInventoryCommands(commands)
+            registerGameModeCommands(commands)
+            registerUtilityCommands(commands)
+            registerWarpCommands(commands)
+            registerHomeCommands(commands)
+            registerEconomyCommands(commands)
+            registerKitCommands(commands)
+            registerTimeCommands(commands)
+            registerWeatherCommands(commands)
         }
+    }
+
+    private fun registerPluginManagementCommands(commands: CommandRegistrar) {
+        commands.register(
+            createBasicXCommand(),
+            "Plugin management"
+        )
+    }
+
+    private fun registerTeleportationCommands(commands: CommandRegistrar) {
+        commands.register(
+            createTPCommand(),
+            "Teleport to a player or coordinates"
+        )
+
+        commands.register(
+            createTPACommand(),
+            "Request to teleport to a player"
+        )
+    }
+
+    private fun registerInventoryCommands(commands: CommandRegistrar) {
+        commands.register(
+            registerInvSeeCommand(),
+            "View another player's inventory"
+        )
+    }
+
+    private fun registerGameModeCommands(commands: CommandRegistrar) {
+        commands.register(
+            createGMCommand(),
+            "Change game mode"
+        )
+    }
+
+    private fun registerUtilityCommands(commands: CommandRegistrar) {
+        commands.register(
+            VanishCommand().createVanishCommand(),
+            "Toggle vanish mode"
+        )
+
+        commands.register(
+            ItemEditCommand().register().build(),
+            "Edit items (sign, enchant, rename)"
+        )
+
+        commands.register(
+            createTrashCommand(),
+            "Open trash GUI"
+        )
+
+        commands.register(
+            FeedCommand.createFeedCommand(),
+            "Feed a player"
+        )
+
+        commands.register(
+            HealCommand.createHealCommand(),
+            "Heal a player"
+        )
+
+        commands.register(
+            FlyCommand.createFlyCommand(),
+            "Toggle fly mode"
+        )
+
+        commands.register(
+            AnvilCommand.register(),
+            "Open anvil GUI"
+        )
+    }
+
+    private fun registerWarpCommands(commands: CommandRegistrar) {
+        commands.register(
+            WarpCommand.createWarpCommand(),
+            "Warp to a location"
+        )
+
+        commands.register(
+            CreateWarpCommand.createWarpCommand(),
+            "Create a warp"
+        )
+
+        commands.register(
+            DeleteWarpCommand.createDeleteWarpCommand(),
+            "Delete a warp"
+        )
+    }
+
+    private fun registerHomeCommands(commands: CommandRegistrar) {
+        commands.register(
+            HomesCommand.createHomesCommand(),
+            "Manage homes"
+        )
+    }
+
+    private fun registerEconomyCommands(commands: CommandRegistrar) {
+        commands.register(
+            createEconomyCommand(),
+            "Economy commands"
+        )
+    }
+
+    private fun registerKitCommands(commands: CommandRegistrar) {
+        commands.register(
+            KitCommand.createKitCommand(),
+            "Receive a kit"
+        )
+    }
+
+    private fun registerTimeCommands(commands: CommandRegistrar) {
+        commands.register(
+            createTimeCommand(),
+            "Set or add time"
+        )
+    }
+
+    private fun registerWeatherCommands(commands: CommandRegistrar) {
+        commands.register(
+            WeatherCommand().createWeatherCommand(),
+            "Set weather"
+        )
     }
 }

--- a/src/main/kotlin/cc/modlabs/basicx/CommandBootstrapper.kt
+++ b/src/main/kotlin/cc/modlabs/basicx/CommandBootstrapper.kt
@@ -1,6 +1,7 @@
 package cc.modlabs.basicx
 
 import cc.modlabs.basicx.commands.*
+import io.papermc.paper.command.brigadier.Commands
 import io.papermc.paper.plugin.bootstrap.BootstrapContext
 import io.papermc.paper.plugin.bootstrap.PluginBootstrap
 import io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents
@@ -27,14 +28,14 @@ class CommandBootstrapper : PluginBootstrap {
         }
     }
 
-    private fun registerPluginManagementCommands(commands: CommandRegistrar) {
+    private fun registerPluginManagementCommands(commands: Commands) {
         commands.register(
             createBasicXCommand(),
             "Plugin management"
         )
     }
 
-    private fun registerTeleportationCommands(commands: CommandRegistrar) {
+    private fun registerTeleportationCommands(commands: Commands) {
         commands.register(
             createTPCommand(),
             "Teleport to a player or coordinates"
@@ -46,21 +47,21 @@ class CommandBootstrapper : PluginBootstrap {
         )
     }
 
-    private fun registerInventoryCommands(commands: CommandRegistrar) {
+    private fun registerInventoryCommands(commands: Commands) {
         commands.register(
             registerInvSeeCommand(),
             "View another player's inventory"
         )
     }
 
-    private fun registerGameModeCommands(commands: CommandRegistrar) {
+    private fun registerGameModeCommands(commands: Commands) {
         commands.register(
             createGMCommand(),
             "Change game mode"
         )
     }
 
-    private fun registerUtilityCommands(commands: CommandRegistrar) {
+    private fun registerUtilityCommands(commands: Commands) {
         commands.register(
             VanishCommand().createVanishCommand(),
             "Toggle vanish mode"
@@ -97,10 +98,11 @@ class CommandBootstrapper : PluginBootstrap {
         )
     }
 
-    private fun registerWarpCommands(commands: CommandRegistrar) {
+    private fun registerWarpCommands(commands: Commands) {
         commands.register(
             WarpCommand.createWarpCommand(),
-            "Warp to a location"
+            "Warp to a location",
+            listOf("warps")
         )
 
         commands.register(
@@ -110,39 +112,41 @@ class CommandBootstrapper : PluginBootstrap {
 
         commands.register(
             DeleteWarpCommand.createDeleteWarpCommand(),
-            "Delete a warp"
+            "Delete a warp",
+            listOf("delwarp")
         )
     }
 
-    private fun registerHomeCommands(commands: CommandRegistrar) {
+    private fun registerHomeCommands(commands: Commands) {
         commands.register(
             HomesCommand.createHomesCommand(),
-            "Manage homes"
+            "Manage homes",
+            listOf("home")
         )
     }
 
-    private fun registerEconomyCommands(commands: CommandRegistrar) {
+    private fun registerEconomyCommands(commands: Commands) {
         commands.register(
             createEconomyCommand(),
             "Economy commands"
         )
     }
 
-    private fun registerKitCommands(commands: CommandRegistrar) {
+    private fun registerKitCommands(commands: Commands) {
         commands.register(
             KitCommand.createKitCommand(),
             "Receive a kit"
         )
     }
 
-    private fun registerTimeCommands(commands: CommandRegistrar) {
+    private fun registerTimeCommands(commands: Commands) {
         commands.register(
             createTimeCommand(),
             "Set or add time"
         )
     }
 
-    private fun registerWeatherCommands(commands: CommandRegistrar) {
+    private fun registerWeatherCommands(commands: Commands) {
         commands.register(
             WeatherCommand().createWeatherCommand(),
             "Set weather"

--- a/src/main/kotlin/cc/modlabs/basicx/Variables.kt
+++ b/src/main/kotlin/cc/modlabs/basicx/Variables.kt
@@ -1,6 +1,0 @@
-package cc.modlabs.basicx
-
-import cc.modlabs.basicx.cache.MessageCache
-
-val PREFIX: String
-    get() = MessageCache.getMessage("general.prefix", default = "<gradient:#4a69bd:#6a89cc>WorldEngine</gradient> <color:#4a628f>>></color> <color:#b2c2d4>")

--- a/src/main/kotlin/cc/modlabs/basicx/cache/HomeCache.kt
+++ b/src/main/kotlin/cc/modlabs/basicx/cache/HomeCache.kt
@@ -12,12 +12,26 @@ object HomeCache {
     private val cacheLock: ReadWriteLock = ReentrantReadWriteLock()
     private var cache: MutableMap<UUID, MutableMap<String, Location>> = mutableMapOf()
 
+    val homeAmount: Int
+        get() = cache.values.sumOf { it.size }
+
+    val homedPlayers: Int
+        get() = cache.size
+
     fun getHome(playerUUID: UUID, homeName: String): Location? {
         cacheLock.readLock().lock()
         val playerHomes = cache[playerUUID]
         val location = playerHomes?.get(homeName)
         cacheLock.readLock().unlock()
         return location
+    }
+
+    fun getHomes(playerUUID: UUID): List<String> {
+        cacheLock.readLock().lock()
+        val playerHomes = cache[playerUUID]
+        val homes = playerHomes?.keys?.toList() ?: emptyList()
+        cacheLock.readLock().unlock()
+        return homes
     }
 
     fun addHome(playerUUID: UUID, homeName: String, location: Location) {
@@ -68,12 +82,12 @@ object HomeCache {
 
         cache.forEach { (playerKey, playerHomes) ->
             playerHomes.forEach { (homeKey, location) ->
-                homesFile.set("$playerKey.$homeKey.world", location.world?.name)
-                homesFile.set("$playerKey.$homeKey.x", location.x)
-                homesFile.set("$playerKey.$homeKey.y", location.y)
-                homesFile.set("$playerKey.$homeKey.z", location.z)
-                homesFile.set("$playerKey.$homeKey.yaw", location.yaw)
-                homesFile.set("$playerKey.$homeKey.pitch", location.pitch)
+                homesFile["$playerKey.$homeKey.world"] = location.world?.name
+                homesFile["$playerKey.$homeKey.x"] = location.x
+                homesFile["$playerKey.$homeKey.y"] = location.y
+                homesFile["$playerKey.$homeKey.z"] = location.z
+                homesFile["$playerKey.$homeKey.yaw"] = location.yaw
+                homesFile["$playerKey.$homeKey.pitch"] = location.pitch
             }
         }
 

--- a/src/main/kotlin/cc/modlabs/basicx/cache/HomeCache.kt
+++ b/src/main/kotlin/cc/modlabs/basicx/cache/HomeCache.kt
@@ -1,0 +1,82 @@
+package cc.modlabs.basicx.cache
+
+import cc.modlabs.basicx.utils.FileConfig
+import org.bukkit.Bukkit
+import org.bukkit.Location
+import java.util.UUID
+import java.util.concurrent.locks.ReadWriteLock
+import java.util.concurrent.locks.ReentrantReadWriteLock
+
+object HomeCache {
+
+    private val cacheLock: ReadWriteLock = ReentrantReadWriteLock()
+    private var cache: MutableMap<UUID, MutableMap<String, Location>> = mutableMapOf()
+
+    fun getHome(playerUUID: UUID, homeName: String): Location? {
+        cacheLock.readLock().lock()
+        val playerHomes = cache[playerUUID]
+        val location = playerHomes?.get(homeName)
+        cacheLock.readLock().unlock()
+        return location
+    }
+
+    fun addHome(playerUUID: UUID, homeName: String, location: Location) {
+        cacheLock.writeLock().lock()
+        val playerHomes = cache.getOrPut(playerUUID) { mutableMapOf() }
+        playerHomes[homeName] = location
+        saveCache()
+        cacheLock.writeLock().unlock()
+    }
+
+    fun removeHome(playerUUID: UUID, homeName: String) {
+        cacheLock.writeLock().lock()
+        val playerHomes = cache[playerUUID]
+        playerHomes?.remove(homeName)
+        if (playerHomes != null && playerHomes.isEmpty()) {
+            cache.remove(playerUUID)
+        }
+        saveCache()
+        cacheLock.writeLock().unlock()
+    }
+
+    fun loadCache() {
+        cacheLock.writeLock().lock()
+        cache = mutableMapOf()
+
+        val homesFile = FileConfig("homes.yml")
+        homesFile.getKeys(false).forEach { playerKey ->
+            val playerUUID = UUID.fromString(playerKey)
+            val playerHomes = mutableMapOf<String, Location>()
+            homesFile.getConfigurationSection(playerKey)?.getKeys(false)?.forEach { homeKey ->
+                val world = Bukkit.getWorld(homesFile.getString("$playerKey.$homeKey.world") ?: return@forEach)
+                val x = homesFile.getDouble("$playerKey.$homeKey.x")
+                val y = homesFile.getDouble("$playerKey.$homeKey.y")
+                val z = homesFile.getDouble("$playerKey.$homeKey.z")
+                val yaw = homesFile.getDouble("$playerKey.$homeKey.yaw").toFloat()
+                val pitch = homesFile.getDouble("$playerKey.$homeKey.pitch").toFloat()
+                val location = Location(world, x, y, z, yaw, pitch)
+                playerHomes[homeKey] = location
+            }
+            cache[playerUUID] = playerHomes
+        }
+
+        cacheLock.writeLock().unlock()
+    }
+
+    private fun saveCache() {
+        val homesFile = FileConfig("homes.yml")
+
+        cache.forEach { (playerKey, playerHomes) ->
+            playerHomes.forEach { (homeKey, location) ->
+                homesFile.set("$playerKey.$homeKey.world", location.world?.name)
+                homesFile.set("$playerKey.$homeKey.x", location.x)
+                homesFile.set("$playerKey.$homeKey.y", location.y)
+                homesFile.set("$playerKey.$homeKey.z", location.z)
+                homesFile.set("$playerKey.$homeKey.yaw", location.yaw)
+                homesFile.set("$playerKey.$homeKey.pitch", location.pitch)
+            }
+        }
+
+        homesFile.saveConfig()
+    }
+}

--- a/src/main/kotlin/cc/modlabs/basicx/cache/MessageCache.kt
+++ b/src/main/kotlin/cc/modlabs/basicx/cache/MessageCache.kt
@@ -42,7 +42,7 @@ object MessageCache {
             return messagesFile.getString(key) ?: default
         }
 
-        messagesFile[key] = default
+        messagesFile[key] = "\${{variables.prefix}}$default"
         messagesFile.saveConfig()
 
         cacheLock.writeLock().lock()

--- a/src/main/kotlin/cc/modlabs/basicx/cache/MessageCache.kt
+++ b/src/main/kotlin/cc/modlabs/basicx/cache/MessageCache.kt
@@ -13,7 +13,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock
 object MessageCache {
 
     private val cacheLock: ReadWriteLock = ReentrantReadWriteLock()
-    private var cache: Map<String, String> = kotlin.collections.mapOf()
+    private var cache: Map<String, String> = mapOf()
 
     fun getMessage(key: String, commandSender: CommandSender = Bukkit.getConsoleSender(), placeholders: Map<String, Any> = emptyMap<String, String>(), default: String = key): String {
         cacheLock.readLock().lock()
@@ -64,8 +64,23 @@ object MessageCache {
             tempCache[it] = message
         }
 
-        cache = tempCache
+        cache = parsePlaceholders(tempCache)
         cacheLock.writeLock().unlock()
+    }
+
+    private fun parsePlaceholders(tempCache: MutableMap<String, String>): Map<String, String> {
+        val regex = Regex("\\$\\{\\{([a-zA-Z0-9_.]+)\\}\\}")
+        val resolvedCache = mutableMapOf<String, String>()
+
+        tempCache.forEach { (key, value) ->
+            val newValue = regex.replace(value) { matchResult ->
+                val variable = matchResult.groupValues[1]
+                tempCache[variable] ?: matchResult.value // Fallback to the original if not found
+            }
+            resolvedCache[key] = newValue
+        }
+
+        return resolvedCache
     }
 
     // Add placeholders with start and end %

--- a/src/main/kotlin/cc/modlabs/basicx/cache/WarpCache.kt
+++ b/src/main/kotlin/cc/modlabs/basicx/cache/WarpCache.kt
@@ -1,0 +1,68 @@
+package cc.modlabs.basicx.cache
+
+import cc.modlabs.basicx.utils.FileConfig
+import org.bukkit.Bukkit
+import org.bukkit.Location
+import java.util.concurrent.locks.ReadWriteLock
+import java.util.concurrent.locks.ReentrantReadWriteLock
+
+object WarpCache {
+
+    private val cacheLock: ReadWriteLock = ReentrantReadWriteLock()
+    private var cache: MutableMap<String, Location> = mutableMapOf()
+
+    fun getWarp(name: String): Location? {
+        cacheLock.readLock().lock()
+        val location = cache[name]
+        cacheLock.readLock().unlock()
+        return location
+    }
+
+    fun addWarp(name: String, location: Location) {
+        cacheLock.writeLock().lock()
+        cache[name] = location
+        saveCache()
+        cacheLock.writeLock().unlock()
+    }
+
+    fun removeWarp(name: String) {
+        cacheLock.writeLock().lock()
+        cache.remove(name)
+        saveCache()
+        cacheLock.writeLock().unlock()
+    }
+
+    fun loadCache() {
+        cacheLock.writeLock().lock()
+        cache = mutableMapOf()
+
+        val warpsFile = FileConfig("warps.yml")
+        warpsFile.getKeys(false).forEach { key ->
+            val world = Bukkit.getWorld(warpsFile.getString("$key.world") ?: return@forEach)
+            val x = warpsFile.getDouble("$key.x")
+            val y = warpsFile.getDouble("$key.y")
+            val z = warpsFile.getDouble("$key.z")
+            val yaw = warpsFile.getDouble("$key.yaw").toFloat()
+            val pitch = warpsFile.getDouble("$key.pitch").toFloat()
+            val location = Location(world, x, y, z, yaw, pitch)
+            cache[key] = location
+        }
+
+        cacheLock.writeLock().unlock()
+    }
+
+    private fun saveCache() {
+        val warpsFile = FileConfig("warps.yml")
+
+        cache.forEach { (key, location) ->
+            warpsFile.set("$key.world", location.world?.name)
+            warpsFile.set("$key.x", location.x)
+            warpsFile.set("$key.y", location.y)
+            warpsFile.set("$key.z", location.z)
+            warpsFile.set("$key.yaw", location.yaw)
+            warpsFile.set("$key.pitch", location.pitch)
+        }
+
+        warpsFile.saveConfig()
+    }
+}

--- a/src/main/kotlin/cc/modlabs/basicx/cache/WarpCache.kt
+++ b/src/main/kotlin/cc/modlabs/basicx/cache/WarpCache.kt
@@ -11,11 +11,21 @@ object WarpCache {
     private val cacheLock: ReadWriteLock = ReentrantReadWriteLock()
     private var cache: MutableMap<String, Location> = mutableMapOf()
 
+    val warpAmount: Int
+        get() = cache.size
+
     fun getWarp(name: String): Location? {
         cacheLock.readLock().lock()
         val location = cache[name]
         cacheLock.readLock().unlock()
         return location
+    }
+
+    fun getWarps():List<String> {
+        cacheLock.readLock().lock()
+        val warps = cache.keys.toList()
+        cacheLock.readLock().unlock()
+        return warps
     }
 
     fun addWarp(name: String, location: Location) {
@@ -55,12 +65,12 @@ object WarpCache {
         val warpsFile = FileConfig("warps.yml")
 
         cache.forEach { (key, location) ->
-            warpsFile.set("$key.world", location.world?.name)
-            warpsFile.set("$key.x", location.x)
-            warpsFile.set("$key.y", location.y)
-            warpsFile.set("$key.z", location.z)
-            warpsFile.set("$key.yaw", location.yaw)
-            warpsFile.set("$key.pitch", location.pitch)
+            warpsFile["$key.world"] = location.world?.name
+            warpsFile["$key.x"] = location.x
+            warpsFile["$key.y"] = location.y
+            warpsFile["$key.z"] = location.z
+            warpsFile["$key.yaw"] = location.yaw
+            warpsFile["$key.pitch"] = location.pitch
         }
 
         warpsFile.saveConfig()

--- a/src/main/kotlin/cc/modlabs/basicx/commands/BasicXCommand.kt
+++ b/src/main/kotlin/cc/modlabs/basicx/commands/BasicXCommand.kt
@@ -3,7 +3,7 @@ package cc.modlabs.basicx.commands
 
 import cc.modlabs.basicx.BasicX
 import cc.modlabs.basicx.cache.MessageCache
-import cc.modlabs.basicx.extensions.sendMessagePrefixed
+import cc.modlabs.basicx.extensions.send
 import com.mojang.brigadier.Command
 import com.mojang.brigadier.tree.LiteralCommandNode
 import io.papermc.paper.command.brigadier.CommandSourceStack
@@ -13,7 +13,7 @@ fun createBasicXCommand(): LiteralCommandNode<CommandSourceStack> {
     return Commands.literal("basicx")
         .executes { ctx ->
             val sender = ctx.source.sender
-            sender.sendMessagePrefixed("commands.basicx.info.version", mapOf("version" to BasicX.instance.description.version), default = "BasicX version {version}")
+            sender.send("commands.basicx.info.version", mapOf("version" to BasicX.instance.description.version), default = "BasicX version {version}")
             return@executes Command.SINGLE_SUCCESS
         }
         .then(Commands.literal("reload")
@@ -21,9 +21,9 @@ fun createBasicXCommand(): LiteralCommandNode<CommandSourceStack> {
             .executes { ctx ->
                 val sender = ctx.source.sender
 
-                sender.sendMessagePrefixed("commands.basicx.info.reload", default = "<yellow>Reloading config...")
+                sender.send("commands.basicx.info.reload", default = "<yellow>Reloading config...")
                 MessageCache.loadCache()
-                sender.sendMessagePrefixed("commands.basicx.info.reload-success", default = "<green>Config reloaded!")
+                sender.send("commands.basicx.info.reload-success", default = "<green>Config reloaded!")
 
                 return@executes Command.SINGLE_SUCCESS
             }

--- a/src/main/kotlin/cc/modlabs/basicx/commands/CreateWarpCommand.kt
+++ b/src/main/kotlin/cc/modlabs/basicx/commands/CreateWarpCommand.kt
@@ -1,15 +1,11 @@
 package cc.modlabs.basicx.commands
 
-import cc.modlabs.basicx.BasicX
-import cc.modlabs.basicx.cache.MessageCache
-import cc.modlabs.basicx.extensions.sendMessagePrefixed
+import cc.modlabs.basicx.extensions.send
 import com.mojang.brigadier.Command
 import com.mojang.brigadier.arguments.StringArgumentType
-import com.mojang.brigadier.context.CommandContext
 import com.mojang.brigadier.tree.LiteralCommandNode
 import io.papermc.paper.command.brigadier.CommandSourceStack
 import io.papermc.paper.command.brigadier.Commands
-import org.bukkit.Location
 import org.bukkit.command.CommandSender
 import org.bukkit.entity.Player
 
@@ -34,6 +30,6 @@ object CreateWarpCommand {
         val location = player.location
 
         WarpCommand.addWarp(warpName, location)
-        player.sendMessagePrefixed("commands.createwarp.success", mapOf("warpName" to warpName), default = "Warp {warpName} created")
+        player.send("commands.createwarp.success", mapOf("warpName" to warpName), default = "Warp {warpName} created")
     }
 }

--- a/src/main/kotlin/cc/modlabs/basicx/commands/DeleteWarpCommand.kt
+++ b/src/main/kotlin/cc/modlabs/basicx/commands/DeleteWarpCommand.kt
@@ -1,11 +1,8 @@
 package cc.modlabs.basicx.commands
 
-import cc.modlabs.basicx.BasicX
-import cc.modlabs.basicx.cache.MessageCache
-import cc.modlabs.basicx.extensions.sendMessagePrefixed
+import cc.modlabs.basicx.extensions.send
 import com.mojang.brigadier.Command
 import com.mojang.brigadier.arguments.StringArgumentType
-import com.mojang.brigadier.context.CommandContext
 import com.mojang.brigadier.tree.LiteralCommandNode
 import io.papermc.paper.command.brigadier.CommandSourceStack
 import io.papermc.paper.command.brigadier.Commands
@@ -32,6 +29,6 @@ object DeleteWarpCommand {
         val player = sender as? Player ?: return
 
         WarpCommand.removeWarp(warpName)
-        player.sendMessagePrefixed("commands.deletewarp.success", mapOf("warpName" to warpName), default = "Warp {warpName} deleted")
+        player.send("commands.deletewarp.success", mapOf("warpName" to warpName), default = "Warp {warpName} deleted")
     }
 }

--- a/src/main/kotlin/cc/modlabs/basicx/commands/EconomyCommand.kt
+++ b/src/main/kotlin/cc/modlabs/basicx/commands/EconomyCommand.kt
@@ -1,8 +1,6 @@
 package cc.modlabs.basicx.commands
 
-import cc.modlabs.basicx.BasicX
-import cc.modlabs.basicx.cache.MessageCache
-import cc.modlabs.basicx.extensions.sendMessagePrefixed
+import cc.modlabs.basicx.extensions.send
 import com.mojang.brigadier.Command
 import com.mojang.brigadier.arguments.StringArgumentType
 import com.mojang.brigadier.arguments.IntegerArgumentType
@@ -20,9 +18,9 @@ fun createEconomyCommand(): LiteralCommandNode<CommandSourceStack> {
                 val sender = ctx.source.sender
                 if (sender is Player) {
                     val balance = getBalance(sender)
-                    sender.sendMessagePrefixed("commands.economy.balance", mapOf("balance" to balance), default = "Your balance is {balance}")
+                    sender.send("commands.economy.balance", mapOf("balance" to balance), default = "Your balance is {balance}")
                 } else {
-                    sender.sendMessagePrefixed("commands.economy.error", default = "This command can only be used by players.")
+                    sender.send("commands.economy.error", default = "This command can only be used by players.")
                 }
                 return@executes Command.SINGLE_SUCCESS
             }
@@ -38,16 +36,16 @@ fun createEconomyCommand(): LiteralCommandNode<CommandSourceStack> {
                             val target = Bukkit.getPlayer(targetName)
                             if (target != null && target.isOnline) {
                                 if (pay(sender, target, amount)) {
-                                    sender.sendMessagePrefixed("commands.economy.pay.success", mapOf("amount" to amount, "player" to target.name), default = "You paid {amount} to {player}")
-                                    target.sendMessagePrefixed("commands.economy.pay.received", mapOf("amount" to amount, "player" to sender.name), default = "You received {amount} from {player}")
+                                    sender.send("commands.economy.pay.success", mapOf("amount" to amount, "player" to target.name), default = "You paid {amount} to {player}")
+                                    target.send("commands.economy.pay.received", mapOf("amount" to amount, "player" to sender.name), default = "You received {amount} from {player}")
                                 } else {
-                                    sender.sendMessagePrefixed("commands.economy.pay.error", default = "You do not have enough balance.")
+                                    sender.send("commands.economy.pay.error", default = "You do not have enough balance.")
                                 }
                             } else {
-                                sender.sendMessagePrefixed("commands.economy.pay.error", default = "Player not found or not online.")
+                                sender.send("commands.economy.pay.error", default = "Player not found or not online.")
                             }
                         } else {
-                            sender.sendMessagePrefixed("commands.economy.error", default = "This command can only be used by players.")
+                            sender.send("commands.economy.error", default = "This command can only be used by players.")
                         }
                         return@executes Command.SINGLE_SUCCESS
                     }

--- a/src/main/kotlin/cc/modlabs/basicx/commands/FeedCommand.kt
+++ b/src/main/kotlin/cc/modlabs/basicx/commands/FeedCommand.kt
@@ -1,6 +1,6 @@
 package cc.modlabs.basicx.commands
 
-import cc.modlabs.basicx.extensions.sendMessagePrefixed
+import cc.modlabs.basicx.extensions.send
 import com.mojang.brigadier.Command
 import com.mojang.brigadier.arguments.StringArgumentType
 import com.mojang.brigadier.context.CommandContext
@@ -8,7 +8,6 @@ import com.mojang.brigadier.tree.LiteralCommandNode
 import io.papermc.paper.command.brigadier.CommandSourceStack
 import io.papermc.paper.command.brigadier.Commands
 import org.bukkit.Bukkit
-import org.bukkit.entity.Player
 
 class FeedCommand : Command<CommandSourceStack> {
 
@@ -18,14 +17,14 @@ class FeedCommand : Command<CommandSourceStack> {
         val target = Bukkit.getPlayer(targetName)
 
         if (target == null) {
-            sender.sendMessagePrefixed("commands.feed.target-not-found", mapOf("target" to targetName), default = "Player {target} not found.")
+            sender.send("commands.feed.target-not-found", mapOf("target" to targetName), default = "Player {target} not found.")
             return Command.SINGLE_SUCCESS
         }
 
         target.foodLevel = 20
         target.saturation = 20.0f
-        target.sendMessagePrefixed("commands.feed.success", default = "You have been fed.")
-        sender.sendMessagePrefixed("commands.feed.sender-success", mapOf("target" to targetName), default = "You have fed {target}.")
+        target.send("commands.feed.success", default = "You have been fed.")
+        sender.send("commands.feed.sender-success", mapOf("target" to targetName), default = "You have fed {target}.")
 
         return Command.SINGLE_SUCCESS
     }

--- a/src/main/kotlin/cc/modlabs/basicx/commands/FlyCommand.kt
+++ b/src/main/kotlin/cc/modlabs/basicx/commands/FlyCommand.kt
@@ -1,6 +1,6 @@
 package cc.modlabs.basicx.commands
 
-import cc.modlabs.basicx.extensions.sendMessagePrefixed
+import cc.modlabs.basicx.extensions.send
 import com.mojang.brigadier.Command
 import com.mojang.brigadier.arguments.BoolArgumentType
 import com.mojang.brigadier.arguments.StringArgumentType
@@ -9,8 +9,6 @@ import com.mojang.brigadier.tree.LiteralCommandNode
 import io.papermc.paper.command.brigadier.CommandSourceStack
 import io.papermc.paper.command.brigadier.Commands
 import org.bukkit.Bukkit
-import org.bukkit.GameMode
-import org.bukkit.entity.Player
 
 class FlyCommand : Command<CommandSourceStack> {
     override fun run(context: CommandContext<CommandSourceStack>): Int {
@@ -20,14 +18,14 @@ class FlyCommand : Command<CommandSourceStack> {
 
         val target = Bukkit.getPlayer(targetName)
         if (target == null) {
-            sender.sendMessagePrefixed("commands.fly.target-not-found", mapOf("target" to targetName), default = "Player {target} not found.")
+            sender.send("commands.fly.target-not-found", mapOf("target" to targetName), default = "Player {target} not found.")
             return Command.SINGLE_SUCCESS
         }
 
         target.allowFlight = enable
         target.isFlying = enable
 
-        sender.sendMessagePrefixed("commands.fly.success", mapOf("target" to targetName, "enable" to enable), default = "Fly mode for {target} set to {enable}.")
+        sender.send("commands.fly.success", mapOf("target" to targetName, "enable" to enable), default = "Fly mode for {target} set to {enable}.")
         return Command.SINGLE_SUCCESS
     }
 

--- a/src/main/kotlin/cc/modlabs/basicx/commands/GMCommand.kt
+++ b/src/main/kotlin/cc/modlabs/basicx/commands/GMCommand.kt
@@ -1,6 +1,6 @@
 package cc.modlabs.basicx.commands
 
-import cc.modlabs.basicx.extensions.sendMessagePrefixed
+import cc.modlabs.basicx.extensions.send
 import com.mojang.brigadier.Command
 import com.mojang.brigadier.arguments.IntegerArgumentType
 import com.mojang.brigadier.context.CommandContext
@@ -22,7 +22,7 @@ fun createGMCommand(): LiteralCommandNode<CommandSourceStack> {
 private fun setGameMode(ctx: CommandContext<CommandSourceStack>): Int {
     val sender = ctx.source.sender
     if (sender !is Player) {
-        sender.sendMessagePrefixed("commands.gm.not-player", default = "Only players can use this command.")
+        sender.send("commands.gm.not-player", default = "Only players can use this command.")
         return Command.SINGLE_SUCCESS
     }
 
@@ -33,12 +33,12 @@ private fun setGameMode(ctx: CommandContext<CommandSourceStack>): Int {
         2 -> GameMode.ADVENTURE
         3 -> GameMode.SPECTATOR
         else -> {
-            sender.sendMessagePrefixed("commands.gm.invalid-mode", default = "Invalid game mode.")
+            sender.send("commands.gm.invalid-mode", default = "Invalid game mode.")
             return Command.SINGLE_SUCCESS
         }
     }
 
     sender.gameMode = gameMode
-    sender.sendMessagePrefixed("commands.gm.success", mapOf("mode" to gameMode.name), default = "Game mode set to {mode}.")
+    sender.send("commands.gm.success", mapOf("mode" to gameMode.name), default = "Game mode set to {mode}.")
     return Command.SINGLE_SUCCESS
 }

--- a/src/main/kotlin/cc/modlabs/basicx/commands/HealCommand.kt
+++ b/src/main/kotlin/cc/modlabs/basicx/commands/HealCommand.kt
@@ -1,6 +1,6 @@
 package cc.modlabs.basicx.commands
 
-import cc.modlabs.basicx.extensions.sendMessagePrefixed
+import cc.modlabs.basicx.extensions.send
 import com.mojang.brigadier.Command
 import com.mojang.brigadier.arguments.StringArgumentType
 import com.mojang.brigadier.context.CommandContext
@@ -8,7 +8,6 @@ import com.mojang.brigadier.tree.LiteralCommandNode
 import io.papermc.paper.command.brigadier.CommandSourceStack
 import io.papermc.paper.command.brigadier.Commands
 import org.bukkit.Bukkit
-import org.bukkit.entity.Player
 
 class HealCommand : Command<CommandSourceStack> {
 
@@ -18,13 +17,13 @@ class HealCommand : Command<CommandSourceStack> {
         val target = Bukkit.getPlayer(targetName)
 
         if (target == null) {
-            sender.sendMessagePrefixed("commands.heal.target-not-found", mapOf("target" to targetName), default = "Player {target} not found.")
+            sender.send("commands.heal.target-not-found", mapOf("target" to targetName), default = "Player {target} not found.")
             return Command.SINGLE_SUCCESS
         }
 
         target.health = target.maxHealth
-        target.sendMessagePrefixed("commands.heal.success", default = "You have been healed.")
-        sender.sendMessagePrefixed("commands.heal.sender-success", mapOf("target" to targetName), default = "You have healed {target}.")
+        target.send("commands.heal.success", default = "You have been healed.")
+        sender.send("commands.heal.sender-success", mapOf("target" to targetName), default = "You have healed {target}.")
 
         return Command.SINGLE_SUCCESS
     }

--- a/src/main/kotlin/cc/modlabs/basicx/commands/HealCommand.kt
+++ b/src/main/kotlin/cc/modlabs/basicx/commands/HealCommand.kt
@@ -8,6 +8,7 @@ import com.mojang.brigadier.tree.LiteralCommandNode
 import io.papermc.paper.command.brigadier.CommandSourceStack
 import io.papermc.paper.command.brigadier.Commands
 import org.bukkit.Bukkit
+import org.bukkit.attribute.Attribute
 
 class HealCommand : Command<CommandSourceStack> {
 
@@ -21,7 +22,7 @@ class HealCommand : Command<CommandSourceStack> {
             return Command.SINGLE_SUCCESS
         }
 
-        target.health = target.maxHealth
+        target.health = target.getAttribute(Attribute.GENERIC_MAX_HEALTH)?.value ?: 20.0
         target.send("commands.heal.success", default = "You have been healed.")
         sender.send("commands.heal.sender-success", mapOf("target" to targetName), default = "You have healed {target}.")
 

--- a/src/main/kotlin/cc/modlabs/basicx/commands/HomesCommand.kt
+++ b/src/main/kotlin/cc/modlabs/basicx/commands/HomesCommand.kt
@@ -2,6 +2,7 @@ package cc.modlabs.basicx.commands
 
 import cc.modlabs.basicx.BasicX
 import cc.modlabs.basicx.cache.MessageCache
+import cc.modlabs.basicx.cache.HomeCache
 import cc.modlabs.basicx.extensions.sendMessagePrefixed
 import com.mojang.brigadier.Command
 import com.mojang.brigadier.arguments.StringArgumentType
@@ -12,10 +13,9 @@ import io.papermc.paper.command.brigadier.Commands
 import org.bukkit.Location
 import org.bukkit.command.CommandSender
 import org.bukkit.entity.Player
+import java.util.UUID
 
 object HomesCommand {
-
-    private val homes = mutableMapOf<String, Location>()
 
     fun createHomesCommand(): LiteralCommandNode<CommandSourceStack> {
         return Commands.literal("homes")
@@ -56,21 +56,24 @@ object HomesCommand {
     private fun setHome(sender: CommandSender, homeName: String) {
         val player = sender as? Player ?: return
         val location = player.location
+        val playerUUID = player.uniqueId
 
-        homes[homeName] = location
+        HomeCache.addHome(playerUUID, homeName, location)
         player.sendMessagePrefixed("commands.homes.set.success", mapOf("homeName" to homeName), default = "Home {homeName} set")
     }
 
     private fun deleteHome(sender: CommandSender, homeName: String) {
         val player = sender as? Player ?: return
+        val playerUUID = player.uniqueId
 
-        homes.remove(homeName)
+        HomeCache.removeHome(playerUUID, homeName)
         player.sendMessagePrefixed("commands.homes.delete.success", mapOf("homeName" to homeName), default = "Home {homeName} deleted")
     }
 
     private fun teleportHome(sender: CommandSender, homeName: String) {
         val player = sender as? Player ?: return
-        val location = homes[homeName]
+        val playerUUID = player.uniqueId
+        val location = HomeCache.getHome(playerUUID, homeName)
 
         if (location != null) {
             player.teleport(location)

--- a/src/main/kotlin/cc/modlabs/basicx/commands/HomesCommand.kt
+++ b/src/main/kotlin/cc/modlabs/basicx/commands/HomesCommand.kt
@@ -1,29 +1,52 @@
 package cc.modlabs.basicx.commands
 
-import cc.modlabs.basicx.BasicX
-import cc.modlabs.basicx.cache.MessageCache
 import cc.modlabs.basicx.cache.HomeCache
-import cc.modlabs.basicx.extensions.sendMessagePrefixed
+import cc.modlabs.basicx.extensions.send
 import com.mojang.brigadier.Command
 import com.mojang.brigadier.arguments.StringArgumentType
 import com.mojang.brigadier.context.CommandContext
+import com.mojang.brigadier.suggestion.Suggestions
+import com.mojang.brigadier.suggestion.SuggestionsBuilder
 import com.mojang.brigadier.tree.LiteralCommandNode
 import io.papermc.paper.command.brigadier.CommandSourceStack
 import io.papermc.paper.command.brigadier.Commands
-import org.bukkit.Location
 import org.bukkit.command.CommandSender
 import org.bukkit.entity.Player
-import java.util.UUID
+import java.util.concurrent.CompletableFuture
 
 object HomesCommand {
 
     fun createHomesCommand(): LiteralCommandNode<CommandSourceStack> {
         return Commands.literal("homes")
             .requires { it.sender.hasPermission("basicx.homes") }
+            .executes { ctx ->
+                val sender = ctx.source.sender
+                if (sender !is Player) {
+                    sender.send("commands.homes.list-console", mapOf("homes" to HomeCache.homeAmount, "players" to HomeCache.homedPlayers), default = "There are currently <yellow>{homes}</yellow> homes set by a total of <yellow>{players}</yellow> players.")
+                    return@executes Command.SINGLE_SUCCESS
+                }
+               // list all homes for the player
+                val homes = HomeCache.getHomes(sender.uniqueId)
+                if (homes.isEmpty()) {
+                    sender.send("commands.homes.list-empty", default = "You have no homes set.")
+                    return@executes Command.SINGLE_SUCCESS
+                }
+
+                sender.send("commands.homes.list", default = "Your homes are:")
+                for (home in homes) {
+                    sender.send("commands.homes.list-entry", mapOf("home" to home), default = "» <yellow><click:run_command:'/home {home}'><hover:show_text:'Click to teleport to {home}'>{home}</hover></click></yellow>")
+                }
+
+                Command.SINGLE_SUCCESS
+            }
             .then(Commands.literal("set")
                 .then(Commands.argument("homeName", StringArgumentType.string())
                     .executes { ctx ->
                         val sender = ctx.source.sender
+                        if (sender !is Player) {
+                            sender.send("commands.homes.not-player", default = "Only players can use this command.")
+                            return@executes Command.SINGLE_SUCCESS
+                        }
                         val homeName = StringArgumentType.getString(ctx, "homeName")
                         setHome(sender, homeName)
                         Command.SINGLE_SUCCESS
@@ -34,23 +57,44 @@ object HomesCommand {
                 .then(Commands.argument("homeName", StringArgumentType.string())
                     .executes { ctx ->
                         val sender = ctx.source.sender
+                        if (sender !is Player) {
+                            sender.send("commands.homes.not-player", default = "Only players can use this command.")
+                            return@executes Command.SINGLE_SUCCESS
+                        }
                         val homeName = StringArgumentType.getString(ctx, "homeName")
                         deleteHome(sender, homeName)
                         Command.SINGLE_SUCCESS
                     }
+                    .suggests(::suggestHomes)
                 )
             )
-            .then(Commands.literal("teleport")
-                .then(Commands.argument("homeName", StringArgumentType.string())
-                    .executes { ctx ->
-                        val sender = ctx.source.sender
-                        val homeName = StringArgumentType.getString(ctx, "homeName")
-                        teleportHome(sender, homeName)
-                        Command.SINGLE_SUCCESS
+            .then(Commands.argument("homeName", StringArgumentType.string())
+                .executes { ctx ->
+                    val sender = ctx.source.sender
+                    if (sender !is Player) {
+                        sender.send("commands.homes.not-player", default = "Only players can use this command.")
+                        return@executes Command.SINGLE_SUCCESS
                     }
-                )
+                    val homeName = StringArgumentType.getString(ctx, "homeName")
+                    teleportHome(sender, homeName)
+                    Command.SINGLE_SUCCESS
+                }
+                .suggests(::suggestHomes)
             )
             .build()
+    }
+
+    private fun suggestHomes(
+        ctx: CommandContext<CommandSourceStack>,
+        builder: SuggestionsBuilder
+    ): CompletableFuture<Suggestions?>? {
+        val sender = ctx.source.sender
+        if (sender !is Player) return builder.buildFuture()
+        val playerUUID = sender.uniqueId
+        for (home in HomeCache.getHomes(playerUUID)) {
+            builder.suggest(home)
+        }
+        return builder.buildFuture()
     }
 
     private fun setHome(sender: CommandSender, homeName: String) {
@@ -59,7 +103,7 @@ object HomesCommand {
         val playerUUID = player.uniqueId
 
         HomeCache.addHome(playerUUID, homeName, location)
-        player.sendMessagePrefixed("commands.homes.set.success", mapOf("homeName" to homeName), default = "Home {homeName} set")
+        player.send("commands.homes.set.success", mapOf("homeName" to homeName), default = "Home {homeName} set")
     }
 
     private fun deleteHome(sender: CommandSender, homeName: String) {
@@ -67,7 +111,7 @@ object HomesCommand {
         val playerUUID = player.uniqueId
 
         HomeCache.removeHome(playerUUID, homeName)
-        player.sendMessagePrefixed("commands.homes.delete.success", mapOf("homeName" to homeName), default = "Home {homeName} deleted")
+        player.send("commands.homes.delete.success", mapOf("homeName" to homeName), default = "Home {homeName} deleted")
     }
 
     private fun teleportHome(sender: CommandSender, homeName: String) {
@@ -77,9 +121,9 @@ object HomesCommand {
 
         if (location != null) {
             player.teleport(location)
-            player.sendMessagePrefixed("commands.homes.teleport.success", mapOf("homeName" to homeName), default = "Teleported to home {homeName}")
+            player.send("commands.homes.teleport.success", mapOf("homeName" to homeName), default = "Teleported to home {homeName}")
         } else {
-            player.sendMessagePrefixed("commands.homes.not-found", mapOf("homeName" to homeName), default = "Home {homeName} not found")
+            player.send("commands.homes.not-found", mapOf("homeName" to homeName), default = "Home {homeName} not found")
         }
     }
 }

--- a/src/main/kotlin/cc/modlabs/basicx/commands/InvseeCommand.kt
+++ b/src/main/kotlin/cc/modlabs/basicx/commands/InvseeCommand.kt
@@ -1,6 +1,6 @@
 package cc.modlabs.basicx.commands
 
-import cc.modlabs.basicx.extensions.sendMessagePrefixed
+import cc.modlabs.basicx.extensions.send
 import com.mojang.brigadier.Command
 import com.mojang.brigadier.arguments.StringArgumentType
 import com.mojang.brigadier.context.CommandContext
@@ -22,18 +22,18 @@ fun registerInvSeeCommand(): LiteralCommandNode<CommandSourceStack?>? {
 private fun execute(ctx: CommandContext<CommandSourceStack>): Int {
     val sender = ctx.source.sender
     if (sender !is Player) {
-        sender.sendMessagePrefixed("commands.invsee.not-a-player", default = "Only players can use this command.")
+        sender.send("commands.invsee.not-a-player", default = "Only players can use this command.")
         return Command.SINGLE_SUCCESS
     }
 
     val targetName = StringArgumentType.getString(ctx, "player")
     val target = Bukkit.getPlayer(targetName)
     if (target == null) {
-        sender.sendMessagePrefixed("commands.invsee.player-not-found", default = "Player not found.")
+        sender.send("commands.invsee.player-not-found", default = "Player not found.")
         return Command.SINGLE_SUCCESS
     }
 
     sender.openInventory(target.inventory)
-    sender.sendMessagePrefixed("commands.invsee.success", mapOf("player" to target.name), default = "You are now viewing {player}'s inventory.")
+    sender.send("commands.invsee.success", mapOf("player" to target.name), default = "You are now viewing {player}'s inventory.")
     return Command.SINGLE_SUCCESS
 }

--- a/src/main/kotlin/cc/modlabs/basicx/commands/ItemEditCommand.kt
+++ b/src/main/kotlin/cc/modlabs/basicx/commands/ItemEditCommand.kt
@@ -1,6 +1,6 @@
 package cc.modlabs.basicx.commands
 
-import cc.modlabs.basicx.extensions.sendMessagePrefixed
+import cc.modlabs.basicx.extensions.send
 import com.mojang.brigadier.Command
 import com.mojang.brigadier.arguments.IntegerArgumentType
 import com.mojang.brigadier.arguments.StringArgumentType
@@ -11,7 +11,6 @@ import io.papermc.paper.command.brigadier.Commands
 import org.bukkit.Material
 import org.bukkit.enchantments.Enchantment
 import org.bukkit.entity.Player
-import org.bukkit.inventory.meta.ItemMeta
 
 class ItemEditCommand {
 
@@ -42,7 +41,7 @@ class ItemEditCommand {
         val item = player.inventory.itemInMainHand
 
         if (item.type == Material.AIR) {
-            player.sendMessagePrefixed("commands.itemedit.no-item", default = "You must hold an item to sign it.")
+            player.send("commands.itemedit.no-item", default = "You must hold an item to sign it.")
             return Command.SINGLE_SUCCESS
         }
 
@@ -50,7 +49,7 @@ class ItemEditCommand {
         meta?.setDisplayName(name)
         item.itemMeta = meta
 
-        player.sendMessagePrefixed("commands.itemedit.signed", mapOf("name" to name), default = "Item signed with name: $name")
+        player.send("commands.itemedit.signed", mapOf("name" to name), default = "Item signed with name: $name")
         return Command.SINGLE_SUCCESS
     }
 
@@ -59,18 +58,18 @@ class ItemEditCommand {
         val item = player.inventory.itemInMainHand
 
         if (item.type == Material.AIR) {
-            player.sendMessagePrefixed("commands.itemedit.no-item", default = "You must hold an item to enchant it.")
+            player.send("commands.itemedit.no-item", default = "You must hold an item to enchant it.")
             return Command.SINGLE_SUCCESS
         }
 
         val enchant = Enchantment.getByName(enchantment.toUpperCase())
         if (enchant == null) {
-            player.sendMessagePrefixed("commands.itemedit.invalid-enchantment", mapOf("enchantment" to enchantment), default = "Invalid enchantment: $enchantment")
+            player.send("commands.itemedit.invalid-enchantment", mapOf("enchantment" to enchantment), default = "Invalid enchantment: $enchantment")
             return Command.SINGLE_SUCCESS
         }
 
         item.addUnsafeEnchantment(enchant, level)
-        player.sendMessagePrefixed("commands.itemedit.enchanted", mapOf("enchantment" to enchantment, "level" to level), default = "Item enchanted with $enchantment level $level")
+        player.send("commands.itemedit.enchanted", mapOf("enchantment" to enchantment, "level" to level), default = "Item enchanted with $enchantment level $level")
         return Command.SINGLE_SUCCESS
     }
 
@@ -79,7 +78,7 @@ class ItemEditCommand {
         val item = player.inventory.itemInMainHand
 
         if (item.type == Material.AIR) {
-            player.sendMessagePrefixed("commands.itemedit.no-item", default = "You must hold an item to rename it.")
+            player.send("commands.itemedit.no-item", default = "You must hold an item to rename it.")
             return Command.SINGLE_SUCCESS
         }
 
@@ -87,7 +86,7 @@ class ItemEditCommand {
         meta?.setDisplayName(name)
         item.itemMeta = meta
 
-        player.sendMessagePrefixed("commands.itemedit.renamed", mapOf("name" to name), default = "Item renamed to: $name")
+        player.send("commands.itemedit.renamed", mapOf("name" to name), default = "Item renamed to: $name")
         return Command.SINGLE_SUCCESS
     }
 }

--- a/src/main/kotlin/cc/modlabs/basicx/commands/KitCommand.kt
+++ b/src/main/kotlin/cc/modlabs/basicx/commands/KitCommand.kt
@@ -1,15 +1,12 @@
 package cc.modlabs.basicx.commands
 
-import cc.modlabs.basicx.BasicX
-import cc.modlabs.basicx.cache.MessageCache
-import cc.modlabs.basicx.extensions.sendMessagePrefixed
+import cc.modlabs.basicx.extensions.send
 import com.mojang.brigadier.Command
 import com.mojang.brigadier.arguments.StringArgumentType
 import com.mojang.brigadier.context.CommandContext
 import com.mojang.brigadier.tree.LiteralCommandNode
 import io.papermc.paper.command.brigadier.CommandSourceStack
 import io.papermc.paper.command.brigadier.Commands
-import org.bukkit.Bukkit
 import org.bukkit.Material
 import org.bukkit.entity.Player
 import org.bukkit.inventory.ItemStack
@@ -19,19 +16,19 @@ class KitCommand : Command<CommandSourceStack> {
     override fun run(context: CommandContext<CommandSourceStack>): Int {
         val sender = context.source.sender
         if (sender !is Player) {
-            sender.sendMessagePrefixed("commands.kit.not-player", default = "Only players can use this command.")
+            sender.send("commands.kit.not-player", default = "Only players can use this command.")
             return Command.SINGLE_SUCCESS
         }
 
         val kitName = StringArgumentType.getString(context, "kit")
         val kit = getKit(kitName)
         if (kit == null) {
-            sender.sendMessagePrefixed("commands.kit.not-found", mapOf("kit" to kitName), default = "Kit {kit} not found.")
+            sender.send("commands.kit.not-found", mapOf("kit" to kitName), default = "Kit {kit} not found.")
             return Command.SINGLE_SUCCESS
         }
 
         giveKit(sender, kit)
-        sender.sendMessagePrefixed("commands.kit.success", mapOf("kit" to kitName), default = "You have received the {kit} kit.")
+        sender.send("commands.kit.success", mapOf("kit" to kitName), default = "You have received the {kit} kit.")
         return Command.SINGLE_SUCCESS
     }
 

--- a/src/main/kotlin/cc/modlabs/basicx/commands/TPACommand.kt
+++ b/src/main/kotlin/cc/modlabs/basicx/commands/TPACommand.kt
@@ -1,7 +1,6 @@
 package cc.modlabs.basicx.commands
 
-import cc.modlabs.basicx.cache.MessageCache
-import cc.modlabs.basicx.extensions.sendMessagePrefixed
+import cc.modlabs.basicx.extensions.send
 import com.mojang.brigadier.Command
 import com.mojang.brigadier.arguments.StringArgumentType
 import com.mojang.brigadier.context.CommandContext
@@ -23,25 +22,25 @@ private val tpaRequests = mutableMapOf<Player, Player>()
 private fun executeTPA(ctx: CommandContext<CommandSourceStack>): Int {
     val sender = ctx.source.sender
     if (sender !is Player) {
-        sender.sendMessagePrefixed("commands.tpa.not-player", default = "Only players can use this command.")
+        sender.send("commands.tpa.not-player", default = "Only players can use this command.")
         return Command.SINGLE_SUCCESS
     }
 
     val targetName = StringArgumentType.getString(ctx, "player")
     val target = Bukkit.getPlayer(targetName)
     if (target == null) {
-        sender.sendMessagePrefixed("commands.tpa.player-not-found", default = "Player not found.")
+        sender.send("commands.tpa.player-not-found", default = "Player not found.")
         return Command.SINGLE_SUCCESS
     }
 
     if (target == sender) {
-        sender.sendMessagePrefixed("commands.tpa.self-request", default = "You cannot send a teleport request to yourself.")
+        sender.send("commands.tpa.self-request", default = "You cannot send a teleport request to yourself.")
         return Command.SINGLE_SUCCESS
     }
 
     tpaRequests[target] = sender
-    sender.sendMessagePrefixed("commands.tpa.request-sent", mapOf("target" to target.name), default = "Teleport request sent to {target}.")
-    target.sendMessagePrefixed("commands.tpa.request-received", mapOf("sender" to sender.name), default = "{sender} has requested to teleport to you. Type /tpaccept to accept.")
+    sender.send("commands.tpa.request-sent", mapOf("target" to target.name), default = "Teleport request sent to {target}.")
+    target.send("commands.tpa.request-received", mapOf("sender" to sender.name), default = "{sender} has requested to teleport to you. Type /tpaccept to accept.")
 
     return Command.SINGLE_SUCCESS
 }
@@ -50,9 +49,9 @@ fun acceptRequest(target: Player) {
     val sender = tpaRequests.remove(target)
     if (sender != null) {
         sender.teleport(target.location)
-        sender.sendMessagePrefixed("commands.tpa.request-accepted", mapOf("target" to target.name), default = "Teleport request accepted. Teleporting to {target}.")
-        target.sendMessagePrefixed("commands.tpa.request-accepted-target", mapOf("sender" to sender.name), default = "You have accepted {sender}'s teleport request.")
+        sender.send("commands.tpa.request-accepted", mapOf("target" to target.name), default = "Teleport request accepted. Teleporting to {target}.")
+        target.send("commands.tpa.request-accepted-target", mapOf("sender" to sender.name), default = "You have accepted {sender}'s teleport request.")
     } else {
-        target.sendMessagePrefixed("commands.tpa.no-request", default = "You have no pending teleport requests.")
+        target.send("commands.tpa.no-request", default = "You have no pending teleport requests.")
     }
 }

--- a/src/main/kotlin/cc/modlabs/basicx/commands/TPCommand.kt
+++ b/src/main/kotlin/cc/modlabs/basicx/commands/TPCommand.kt
@@ -1,7 +1,6 @@
 package cc.modlabs.basicx.commands
 
-import cc.modlabs.basicx.extensions.sendMessagePrefixed
-import cc.modlabs.basicx.extensions.sendSuccessSound
+import cc.modlabs.basicx.extensions.send
 import cc.modlabs.basicx.extensions.sendTeleportSound
 import com.mojang.brigadier.Command
 import com.mojang.brigadier.arguments.DoubleArgumentType
@@ -35,12 +34,12 @@ private fun executeTPPlayer(ctx: CommandContext<CommandSourceStack>): Int {
     val targetName = StringArgumentType.getString(ctx, "player")
     val target = Bukkit.getPlayer(targetName)
     if (target == null) {
-        sender.sendMessagePrefixed("commands.tp.player-not-found", default = "Player not found.")
+        sender.send("commands.tp.player-not-found", default = "Player not found.")
         return Command.SINGLE_SUCCESS
     }
 
     sender.teleport(target.location)
-    sender.sendMessagePrefixed("commands.tp.success", mapOf("player" to target.name), default = "Teleported to {player}.")
+    sender.send("commands.tp.success", mapOf("player" to target.name), default = "Teleported to {player}.")
     sender.sendTeleportSound()
     return Command.SINGLE_SUCCESS
 }
@@ -58,7 +57,7 @@ private fun executeTPCoordinates(ctx: CommandContext<CommandSourceStack>): Int {
 
     val location = Location(sender.world, x, y, z)
     sender.teleport(location)
-    sender.sendMessagePrefixed("commands.tp.success-coordinates", mapOf("x" to x, "y" to y, "z" to z), default = "Teleported to {x}, {y}, {z}.")
+    sender.send("commands.tp.success-coordinates", mapOf("x" to x, "y" to y, "z" to z), default = "Teleported to {x}, {y}, {z}.")
     sender.sendTeleportSound()
     return Command.SINGLE_SUCCESS
 }

--- a/src/main/kotlin/cc/modlabs/basicx/commands/TimeCommand.kt
+++ b/src/main/kotlin/cc/modlabs/basicx/commands/TimeCommand.kt
@@ -1,13 +1,12 @@
 package cc.modlabs.basicx.commands
 
-import cc.modlabs.basicx.extensions.sendMessagePrefixed
+import cc.modlabs.basicx.extensions.send
 import com.mojang.brigadier.Command
 import com.mojang.brigadier.arguments.IntegerArgumentType
 import com.mojang.brigadier.tree.LiteralCommandNode
 import io.papermc.paper.command.brigadier.CommandSourceStack
 import io.papermc.paper.command.brigadier.Commands
 import org.bukkit.Bukkit
-import org.bukkit.command.CommandSender
 
 fun createTimeCommand(): LiteralCommandNode<CommandSourceStack> {
     return Commands.literal("time")
@@ -17,7 +16,7 @@ fun createTimeCommand(): LiteralCommandNode<CommandSourceStack> {
                 .executes { ctx ->
                     val time = IntegerArgumentType.getInteger(ctx, "time")
                     Bukkit.getWorlds().forEach { it.time = time.toLong() }
-                    ctx.source.sender.sendMessagePrefixed("commands.time.set", mapOf("time" to time), default = "Time set to {time}")
+                    ctx.source.sender.send("commands.time.set", mapOf("time" to time), default = "Time set to {time}")
                     return@executes Command.SINGLE_SUCCESS
                 }
             )
@@ -27,7 +26,7 @@ fun createTimeCommand(): LiteralCommandNode<CommandSourceStack> {
                 .executes { ctx ->
                     val time = IntegerArgumentType.getInteger(ctx, "time")
                     Bukkit.getWorlds().forEach { it.time += time.toLong() }
-                    ctx.source.sender.sendMessagePrefixed("commands.time.add", mapOf("time" to time), default = "Time added by {time}")
+                    ctx.source.sender.send("commands.time.add", mapOf("time" to time), default = "Time added by {time}")
                     return@executes Command.SINGLE_SUCCESS
                 }
             )

--- a/src/main/kotlin/cc/modlabs/basicx/commands/TrashCommand.kt
+++ b/src/main/kotlin/cc/modlabs/basicx/commands/TrashCommand.kt
@@ -1,6 +1,6 @@
 package cc.modlabs.basicx.commands
 
-import cc.modlabs.basicx.extensions.sendMessagePrefixed
+import cc.modlabs.basicx.extensions.send
 import com.mojang.brigadier.Command
 import com.mojang.brigadier.context.CommandContext
 import com.mojang.brigadier.tree.LiteralCommandNode
@@ -23,7 +23,7 @@ private fun openTrashGUI(ctx: CommandContext<CommandSourceStack>): Int {
     val trashInventory = Bukkit.createInventory(null, 27, text("Trash"))
 
     player.openInventory(trashInventory)
-    player.sendMessagePrefixed("commands.trash.open", default = "<green>Trash GUI opened. Dispose of your items here.")
+    player.send("commands.trash.open", default = "<green>Trash GUI opened. Dispose of your items here.")
 
     return Command.SINGLE_SUCCESS
 }

--- a/src/main/kotlin/cc/modlabs/basicx/commands/VanishCommand.kt
+++ b/src/main/kotlin/cc/modlabs/basicx/commands/VanishCommand.kt
@@ -1,7 +1,7 @@
 package cc.modlabs.basicx.commands
 
 import cc.modlabs.basicx.BasicX
-import cc.modlabs.basicx.extensions.sendMessagePrefixed
+import cc.modlabs.basicx.extensions.send
 import com.mojang.brigadier.Command
 import com.mojang.brigadier.arguments.BoolArgumentType
 import com.mojang.brigadier.arguments.StringArgumentType
@@ -35,12 +35,12 @@ class VanishCommand {
         val sender = ctx.source.sender
         val targetPlayer: Player = if (targetPlayerName != null) {
             Bukkit.getPlayer(targetPlayerName) ?: run {
-                sender.sendMessagePrefixed("commands.vanish.player-not-found", mapOf("player" to targetPlayerName), default = "Player {player} not found.")
+                sender.send("commands.vanish.player-not-found", mapOf("player" to targetPlayerName), default = "Player {player} not found.")
                 return Command.SINGLE_SUCCESS
             }
         } else {
             if (sender is Player) sender else {
-                sender.sendMessagePrefixed("commands.vanish.console-usage", default = "Console must specify a player.")
+                sender.send("commands.vanish.console-usage", default = "Console must specify a player.")
                 return Command.SINGLE_SUCCESS
             }
         }
@@ -49,11 +49,11 @@ class VanishCommand {
         if (vanishState) {
             targetPlayer.setMetadata("vanished", FixedMetadataValue(BasicX.instance, true))
             Bukkit.getOnlinePlayers().forEach { it.hidePlayer(BasicX.instance, targetPlayer) }
-            targetPlayer.sendMessagePrefixed("commands.vanish.enabled", default = "You are now vanished.")
+            targetPlayer.send("commands.vanish.enabled", default = "You are now vanished.")
         } else {
             targetPlayer.removeMetadata("vanished", BasicX.instance)
             Bukkit.getOnlinePlayers().forEach { it.showPlayer(BasicX.instance, targetPlayer) }
-            targetPlayer.sendMessagePrefixed("commands.vanish.disabled", default = "You are no longer vanished.")
+            targetPlayer.send("commands.vanish.disabled", default = "You are no longer vanished.")
         }
 
         return Command.SINGLE_SUCCESS

--- a/src/main/kotlin/cc/modlabs/basicx/commands/WarpCommand.kt
+++ b/src/main/kotlin/cc/modlabs/basicx/commands/WarpCommand.kt
@@ -2,6 +2,7 @@ package cc.modlabs.basicx.commands
 
 import cc.modlabs.basicx.BasicX
 import cc.modlabs.basicx.cache.MessageCache
+import cc.modlabs.basicx.cache.WarpCache
 import cc.modlabs.basicx.extensions.sendMessagePrefixed
 import com.mojang.brigadier.Command
 import com.mojang.brigadier.arguments.StringArgumentType
@@ -15,8 +16,6 @@ import org.bukkit.command.CommandSender
 import org.bukkit.entity.Player
 
 object WarpCommand {
-
-    private val warps = mutableMapOf<String, Location>()
 
     fun createWarpCommand(): LiteralCommandNode<CommandSourceStack> {
         return Commands.literal("warp")
@@ -34,7 +33,7 @@ object WarpCommand {
 
     private fun warp(sender: CommandSender, warpName: String) {
         val player = sender as? Player ?: return
-        val location = warps[warpName]
+        val location = WarpCache.getWarp(warpName)
 
         if (location != null) {
             player.teleport(location)
@@ -45,10 +44,10 @@ object WarpCommand {
     }
 
     fun addWarp(warpName: String, location: Location) {
-        warps[warpName] = location
+        WarpCache.addWarp(warpName, location)
     }
 
     fun removeWarp(warpName: String) {
-        warps.remove(warpName)
+        WarpCache.removeWarp(warpName)
     }
 }

--- a/src/main/kotlin/cc/modlabs/basicx/commands/WarpCommand.kt
+++ b/src/main/kotlin/cc/modlabs/basicx/commands/WarpCommand.kt
@@ -1,25 +1,47 @@
 package cc.modlabs.basicx.commands
 
-import cc.modlabs.basicx.BasicX
-import cc.modlabs.basicx.cache.MessageCache
 import cc.modlabs.basicx.cache.WarpCache
-import cc.modlabs.basicx.extensions.sendMessagePrefixed
+import cc.modlabs.basicx.extensions.send
 import com.mojang.brigadier.Command
 import com.mojang.brigadier.arguments.StringArgumentType
 import com.mojang.brigadier.context.CommandContext
+import com.mojang.brigadier.suggestion.Suggestions
+import com.mojang.brigadier.suggestion.SuggestionsBuilder
 import com.mojang.brigadier.tree.LiteralCommandNode
 import io.papermc.paper.command.brigadier.CommandSourceStack
 import io.papermc.paper.command.brigadier.Commands
-import org.bukkit.Bukkit
 import org.bukkit.Location
 import org.bukkit.command.CommandSender
 import org.bukkit.entity.Player
+import java.util.concurrent.CompletableFuture
 
 object WarpCommand {
 
     fun createWarpCommand(): LiteralCommandNode<CommandSourceStack> {
         return Commands.literal("warp")
             .requires { it.sender.hasPermission("basicx.warp") }
+            .executes { ctx ->
+                val sender = ctx.source.sender
+                if (sender !is Player) {
+                    sender.send("commands.warp.list-console", mapOf("warps" to WarpCache.warpAmount), default = "There are currently <yellow>{warps}</yellow> warps set.")
+                    return@executes Command.SINGLE_SUCCESS
+                }
+
+                // list all warps
+                val warps = WarpCache.getWarps()
+                if (warps.isEmpty()) {
+                    sender.send("commands.warp.list-empty", default = "There are no warps set.")
+                    return@executes Command.SINGLE_SUCCESS
+                }
+
+                sender.send("commands.warp.list", mapOf("warps" to WarpCache.warpAmount), default = "There are <yellow>{warps}</yellow> warps:")
+                for (warp in warps) {
+                    sender.send("commands.warp.list-entry", mapOf("warp" to warp), default = "» <yellow><click:run_command:'/warp {warp}'><hover:show_text:'Click to warp to {warp}'>{warp}</hover></click></yellow>")
+                }
+
+
+                Command.SINGLE_SUCCESS
+            }
             .then(Commands.argument("warpName", StringArgumentType.string())
                 .executes { ctx ->
                     val sender = ctx.source.sender
@@ -27,8 +49,19 @@ object WarpCommand {
                     warp(sender, warpName)
                     Command.SINGLE_SUCCESS
                 }
+                .suggests(::suggestWarps)
             )
             .build()
+    }
+
+    private fun suggestWarps(
+        ctx: CommandContext<CommandSourceStack>,
+        builder: SuggestionsBuilder
+    ): CompletableFuture<Suggestions?>? {
+        for (home in WarpCache.getWarps()) {
+            builder.suggest(home)
+        }
+        return builder.buildFuture()
     }
 
     private fun warp(sender: CommandSender, warpName: String) {
@@ -37,9 +70,9 @@ object WarpCommand {
 
         if (location != null) {
             player.teleport(location)
-            player.sendMessagePrefixed("commands.warp.success", mapOf("warpName" to warpName), default = "Warped to {warpName}")
+            player.send("commands.warp.success", mapOf("warpName" to warpName), default = "Warped to {warpName}")
         } else {
-            player.sendMessagePrefixed("commands.warp.not-found", mapOf("warpName" to warpName), default = "Warp {warpName} not found")
+            player.send("commands.warp.not-found", mapOf("warpName" to warpName), default = "Warp {warpName} not found")
         }
     }
 

--- a/src/main/kotlin/cc/modlabs/basicx/commands/WeatherCommand.kt
+++ b/src/main/kotlin/cc/modlabs/basicx/commands/WeatherCommand.kt
@@ -1,6 +1,6 @@
 package cc.modlabs.basicx.commands
 
-import cc.modlabs.basicx.extensions.sendMessagePrefixed
+import cc.modlabs.basicx.extensions.send
 import com.mojang.brigadier.Command
 import com.mojang.brigadier.arguments.StringArgumentType
 import com.mojang.brigadier.context.CommandContext
@@ -8,7 +8,6 @@ import com.mojang.brigadier.tree.LiteralCommandNode
 import io.papermc.paper.command.brigadier.CommandSourceStack
 import io.papermc.paper.command.brigadier.Commands
 import org.bukkit.Bukkit
-import org.bukkit.WeatherType
 
 class WeatherCommand {
 
@@ -34,18 +33,18 @@ class WeatherCommand {
         when (type) {
             "clear" -> {
                 Bukkit.getWorlds().forEach { it.setStorm(false); it.isThundering = false }
-                sender.sendMessagePrefixed("commands.weather.set", mapOf("type" to "clear"), default = "Weather set to {type}")
+                sender.send("commands.weather.set", mapOf("type" to "clear"), default = "Weather set to {type}")
             }
             "rain" -> {
                 Bukkit.getWorlds().forEach { it.setStorm(true); it.isThundering = false }
-                sender.sendMessagePrefixed("commands.weather.set", mapOf("type" to "rain"), default = "Weather set to {type}")
+                sender.send("commands.weather.set", mapOf("type" to "rain"), default = "Weather set to {type}")
             }
             "thunder" -> {
                 Bukkit.getWorlds().forEach { it.setStorm(true); it.isThundering = true }
-                sender.sendMessagePrefixed("commands.weather.set", mapOf("type" to "thunder"), default = "Weather set to {type}")
+                sender.send("commands.weather.set", mapOf("type" to "thunder"), default = "Weather set to {type}")
             }
             else -> {
-                sender.sendMessagePrefixed("commands.weather.invalid", default = "Invalid weather type")
+                sender.send("commands.weather.invalid", default = "Invalid weather type")
                 return Command.SINGLE_SUCCESS
             }
         }

--- a/src/main/kotlin/cc/modlabs/basicx/extensions/PlayerExtensions.kt
+++ b/src/main/kotlin/cc/modlabs/basicx/extensions/PlayerExtensions.kt
@@ -1,19 +1,18 @@
 package cc.modlabs.basicx.extensions
 
-import cc.modlabs.basicx.PREFIX
 import cc.modlabs.basicx.cache.MessageCache
 import dev.fruxz.stacked.text
 import org.bukkit.*
 import org.bukkit.command.CommandSender
 import org.bukkit.entity.Player
 
-fun Player.sendMessagePrefixed(key: String, placeholders: Map<String, Any> = emptyMap<String, String>(), default: String = key) {
-    this.sendMessage(text(PREFIX + MessageCache.getMessage(key, this, placeholders, default)))
+fun Player.send(key: String, placeholders: Map<String, Any> = emptyMap<String, String>(), default: String = key) {
+    this.sendMessage(text(MessageCache.getMessage(key, this, placeholders, default)))
 }
 
-fun CommandSender.sendMessagePrefixed(key: String, placeholders: Map<String, Any> = emptyMap<String, String>(), default: String = key) = sendMessage(text(PREFIX + MessageCache.getMessage(key, this, placeholders, default)))
+fun CommandSender.send(key: String, placeholders: Map<String, Any> = emptyMap<String, String>(), default: String = key) = sendMessage(text(MessageCache.getMessage(key, this, placeholders, default)))
 
-fun broadcastPrefixed(key: String, placeholders: Map<String, Any> = emptyMap<String, String>(), default: String = key) = Bukkit.broadcast(text(PREFIX + MessageCache.getMessage(key, Bukkit.getConsoleSender(), placeholders, default)))
+fun broadcast(key: String, placeholders: Map<String, Any> = emptyMap<String, String>(), default: String =key) = Bukkit.broadcast(text(MessageCache.getMessage(key, Bukkit.getConsoleSender(), placeholders, default)))
 
 fun CommandSender.sendEmtpyLine() = sendMessage(text(" "))
 

--- a/src/main/kotlin/cc/modlabs/basicx/managers/RegisterManager.kt
+++ b/src/main/kotlin/cc/modlabs/basicx/managers/RegisterManager.kt
@@ -26,8 +26,8 @@ object RegisterManager {
                         if (clazzType.isInstance(loadedClass.javaObjectType.getDeclaredConstructor().newInstance())) {
                             classes.add(loadedClass as KClass<out T>)
                         }
-                    } catch (_: Exception) {
-                        // Ignore
+                    } catch (e: Exception) {
+                        logger.error("Failed to load class: ${classInfo.name}", e)
                     }
                 }
             }
@@ -50,9 +50,13 @@ object RegisterManager {
 
         var amountListeners = 0
         listenerClasses.forEach {
-            val listener = it.primaryConstructor?.call() as Listener
-            Bukkit.getPluginManager().registerEvents(listener, plugin)
-            amountListeners++
+            try {
+                val listener = it.primaryConstructor?.call() as Listener
+                Bukkit.getPluginManager().registerEvents(listener, plugin)
+                amountListeners++
+            } catch (e: Exception) {
+                logger.error("Failed to register listener: ${it.simpleName}", e)
+            }
         }
         logger.info("Registered $amountListeners listeners")
     }

--- a/src/main/kotlin/cc/modlabs/basicx/managers/RegisterManager.kt
+++ b/src/main/kotlin/cc/modlabs/basicx/managers/RegisterManager.kt
@@ -26,8 +26,8 @@ object RegisterManager {
                         if (clazzType.isInstance(loadedClass.javaObjectType.getDeclaredConstructor().newInstance())) {
                             classes.add(loadedClass as KClass<out T>)
                         }
-                    } catch (e: Exception) {
-                        logger.error("Failed to load class: ${classInfo.name}", e)
+                    } catch (_: Exception) {
+                        // Ignore, as this is not a class we need to load
                     }
                 }
             }

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -1,50 +1,58 @@
-general:
-  prefix: "<gradient:#4a69bd:#6a89cc>BasicX</gradient> <color:#4a628f>>></color> <color:#b2c2d4>"
+
+### Variables are a way to reuse objects in your messages
+## You can define you own variables if you like.
+## Use them by including ${{variables.your-variable}} anywhere in this file
+variables:
+  prefix: <gradient:#4a69bd:#6a89cc>BasicX</gradient> <color:#4a628f>>></color> <color:#b2c2d4>
 
 commands:
   basicx:
     info:
-      version: BasicX version {version}
-      reload: <yellow>Reloading config...
-      reload-success: <green>Config reloaded!
+      version: ${{variables.prefix}} BasicX version {version}
+      reload: ${{variables.prefix}} <yellow>Reloading config...
+      reload-success: ${{variables.prefix}} <green>Config reloaded!
   joinquit:
     join: <#C4E538>+ <#dfe6e9>%luckperms_prefix%{displayname}
     quit: <#EA2027>- <#dfe6e9>%luckperms_prefix%{displayname}
   economy:
-    balance: Your balance is {balance}
+    balance: ${{variables.prefix}} Your balance is {balance}
   feed:
-    success: You have been fed.
-    sender-success: You have fed {target}.
+    success: ${{variables.prefix}} You have been fed.
+    sender-success: ${{variables.prefix}} You have fed {target}.
   heal:
-    success: You have been healed.
-    sender-success: You have healed {target}.
+    success: ${{variables.prefix}} You have been healed.
+    sender-success: ${{variables.prefix}} You have healed {target}.
   gm:
-    success: Game mode set to {mode}.
+    success: ${{variables.prefix}} Game mode set to {mode}.
   invsee:
-    success: You are now viewing {player}'s inventory.
+    success: ${{variables.prefix}} You are now viewing {player}'s inventory.
   itemedit:
-    signed: 'Item signed with name: Krass'
-    renamed: 'Item renamed to: Penis'
-    invalid-enchantment: 'Invalid enchantment: Poison'
+    invalid-enchantment: '${{variables.prefix}} Invalid enchantment: Poison'
   kit:
-    success: You have received the {kit} kit.
-  time:
-    set: Time set to 2
-    add: Time added by 2
+    success: ${{variables.prefix}} You have received the {kit} kit.
   tpa:
-    self-request: You cannot send a teleport request to yourself.
+    self-request: ${{variables.prefix}} You cannot send a teleport request to yourself.
   trash:
-    open: <green>Trash GUI opened. Dispose of your items here.
+    open: ${{variables.prefix}} <green>Trash GUI opened. Dispose of your items here.
   weather:
-    set: Weather set to {type}
+    set: ${{variables.prefix}} Weather set to {type}
   homes:
     set:
-      success: Home {homeName} set
+      success: ${{variables.prefix}} Home {homeName} set
     teleport:
-      success: Teleported to home {homeName}
+      success: ${{variables.prefix}} Teleported to home {homeName}
     delete:
-      success: Home {homeName} deleted
-    not-found: Home {homeName} not found
+      success: ${{variables.prefix}} Home {homeName} deleted
+    not-found: ${{variables.prefix}} Home {homeName} not found
+    list: '${{variables.prefix}} Your homes are:'
+    list-entry: » <yellow><click:run_command:'/home {home}'>{home}</click></yellow>
   fly:
-    success: Fly mode for {target} set to {enable}.
-
+    success: ${{variables.prefix}} Fly mode for {target} set to {enable}.
+  warp:
+    list-empty: ${{variables.prefix}} There are no warps set.
+    list: '${{variables.prefix}} There are <yellow>{warps}</yellow> warps:'
+    list-entry: » <yellow><click:run_command:'/warp {warp}'><hover:show_text:'Click
+      to warp to {warp}'>{warp}</hover></click></yellow>
+    success: ${{variables.prefix}} Warped to {warpName}
+  createwarp:
+    success: ${{variables.prefix}} Warp {warpName} created


### PR DESCRIPTION
Add caching and persistent storage for warps and homes.

* Implement `WarpCache` and `HomeCache` objects for caching warps and homes, respectively, with methods for loading, saving, and managing data in `warps.yml` and `homes.yml` files.
* Modify `BasicX.kt` to load `WarpCache` and `HomeCache` during plugin startup.
* Update `WarpCommand.kt` to use `WarpCache` for managing warps instead of an in-memory map.
* Update `HomesCommand.kt` to use `HomeCache` for managing homes instead of an in-memory map, and store homes per player using UUIDs.
* Refactor `CommandBootstrapper.kt` to modularize the command registration process.
* Improve error handling and logging in `RegisterManager.kt`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ModLabsCC/Basicx/pull/2?shareId=d07469ba-62d4-4b64-95db-51e196219eb2).